### PR TITLE
Added yaml side file support

### DIFF
--- a/examples/yaml_parameterized.side
+++ b/examples/yaml_parameterized.side
@@ -1,0 +1,57 @@
+id: bc8471d4-bf4b-4a5c-a8b8-3ae895246541
+version: '2.0'
+name: 'Parameterized testing (yaml)'
+url: https://www.seleniumeasy.com
+urls: ['https://www.seleniumeasy.com/']
+plugins: []
+suites:
+- id: 50c3ab25-7839-47fb-a499-6157f182e2a0
+  name: 'Input message (yaml)'
+  parallel: false
+  persistSession: true
+  tests: [65e3f4b8-4e0e-47db-b49b-38a8de4daa08]
+  timeout: 300
+tests:
+- id: 65e3f4b8-4e0e-47db-b49b-38a8de4daa08
+  name: Input form
+  commands:
+  - command: open
+    comment: ''
+    id: 29115901-2d6b-43d1-94a9-3ef98e9cfbe9
+    target: /test/basic-first-form-demo.html
+    targets: []
+    value: ''
+  - command: type
+    comment: ''
+    id: f9eb72dd-2245-4862-9a20-83583794496c
+    target: id=user-message
+    targets:
+    - [id=user-message, id]
+    - ['css=.form-group > #user-message', 'css:finder']
+    - ['xpath=//input[@id=''user-message'']', 'xpath:attributes']
+    - ['xpath=//form[@id=''get-input'']/div/input', 'xpath:idRelative']
+    - [xpath=//input, 'xpath:position']
+    value: '{$ message $}'
+  - command: click
+    comment: ''
+    id: 8b195663-ab17-4fcb-ae39-f252de069527
+    target: css=.btn:nth-child(2)
+    targets:
+    - ['css=.btn:nth-child(2)', 'css:finder']
+    - ['xpath=(//button[@type=''button''])[2]', 'xpath:attributes']
+    - ['xpath=//form[@id=''get-input'']/button', 'xpath:idRelative']
+    - [xpath=//form/button, 'xpath:position']
+    - ['xpath=//button[contains(.,''Show Message'')]', 'xpath:innerText']
+    value: ''
+  - command: verifyText
+    comment: ''
+    id: 68a86db8-7e9b-44d7-b8c1-1cca2917fdd5
+    target: id=display
+    targets:
+    - [id=display, id]
+    - [css=#display, 'css:finder']
+    - ['xpath=//span[@id=''display'']', 'xpath:attributes']
+    - ['xpath=//div[@id=''user-message'']/span', 'xpath:idRelative']
+    - [xpath=//div/span, 'xpath:position']
+    - ['xpath=//span[contains(.,''Message'')]', 'xpath:innerText']
+    value: '{$ message $}'

--- a/examples/yaml_parameterized_params.yml
+++ b/examples/yaml_parameterized_params.yml
@@ -1,0 +1,4 @@
+- test_name: Input form
+  params_type: list
+  params:
+  - message: FooBar

--- a/side_runner_py/main.py
+++ b/side_runner_py/main.py
@@ -193,12 +193,15 @@ def _get_side_file_list_by_glob(pattern):
     # get SIDE file and param file absolute path pair
     base_dir = pathlib.Path(pattern).parent
     for side_filename in base_dir.glob(pathlib.Path(pattern).name):
-        param_file_fullpath = base_dir / '{}_params.json'.format(side_filename.stem)
+        extentions = ['json', 'yml', 'yaml']
+        param_file_fullpaths = [base_dir / '{}_params.{}'.format(side_filename.stem, ext) for ext in extentions]
         side_file_fullpath = base_dir / side_filename
-        if not param_file_fullpath.exists():
-            yield (side_file_fullpath, None)
+        for param_file_fullpath in param_file_fullpaths:
+            if param_file_fullpath.exists():
+                yield (side_file_fullpath, param_file_fullpath)
+                break
         else:
-            yield (side_file_fullpath, param_file_fullpath)
+            yield (side_file_fullpath, None)
 
 
 def main():

--- a/side_runner_py/side.py
+++ b/side_runner_py/side.py
@@ -1,4 +1,5 @@
 import json
+import yaml
 from copy import deepcopy
 from itertools import product
 from functools import reduce

--- a/side_runner_py/side.py
+++ b/side_runner_py/side.py
@@ -50,7 +50,7 @@ class SIDEProjectManager:
         # parse json
         test_project = {}
         with open(filename, 'r') as f:
-            test_project = json.load(f)
+            test_project = _try_to_load(f)
 
         # load test suites
         test_suites = test_project['suites']
@@ -65,7 +65,7 @@ class SIDEProjectManager:
     def _attach_params(self, params_filename, tests):
         # parse json
         with open(params_filename, 'r') as f:
-            test_params = json.load(f)
+            test_params = _try_to_load(f)
 
         # calc matrix param
         for test_param in test_params:
@@ -161,6 +161,18 @@ def _dict_product(d):
         return acc
 
     return [reduce(_combine, item, {}) for item in product(*[[{k: v} for v in arr] for k, arr in d.items()])]
+
+
+def _try_to_load(f):
+    s = f.read()
+    try:
+        return json.loads(s)
+    except Exception as json_exc:
+        try:
+            return yaml.safe_load(s)
+        except Exception:
+            # always throws json decode error
+            raise json_exc
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -16,6 +16,16 @@ def test_get_side_fixed_file_list_by_glob(tmp_path):
     assert len(list(main._get_side_file_list_by_glob(str(sidefile)))) == 1
 
 
+@pytest.mark.parametrize('extension', [('json'), ('yml'), ('yaml')])
+def test_get_side_params_file(tmp_path, extension):
+    sidefile = tmp_path / "a.json"
+    sidefile.write_text("[]")
+    paramsfile = tmp_path / "a_params.{}".format(extension)
+    paramsfile.write_text("[]")
+    side_fullpath, params_fullpath = list(main._get_side_file_list_by_glob(str(sidefile)))[0]
+    assert str(params_fullpath) == str(paramsfile)
+
+
 def test_main_with_glob_no_match(mocker):
     mocker.patch('side_runner_py.main.with_retry')
     os.environ["SIDE_FILE"] = "foobar_not_existed_filename.side"

--- a/tests/unit/test_side.py
+++ b/tests/unit/test_side.py
@@ -136,3 +136,13 @@ class TestSIDEProjectManager:
         assert test_suites_a == orig_test_project_a['suites']
         assert tests_a == {'foobar_a': {'id': 'foobar_a'}}
         assert tests_b == {'foobar_a': {'id': 'foobar_a'}, 'foobar_b': {'id': 'foobar_b'}}
+
+    def test_parse_yaml_side_file(self, mocker):
+        mocker.patch('side_runner_py.side.open')
+        mocker.patch('json.load').side_effect = Exception()
+        mocker.patch('yaml.safe_load').return_value = {}
+
+        tests = []
+        side_manager = SIDEProjectManager()
+        side_manager._attach_params('foobar.yml', tests)
+        assert tests == []

--- a/tests/unit/test_side.py
+++ b/tests/unit/test_side.py
@@ -1,4 +1,5 @@
 import json
+import yaml
 import pytest
 from side_runner_py.side import SIDEProjectManager
 
@@ -6,13 +7,13 @@ from side_runner_py.side import SIDEProjectManager
 class TestSIDEProjectManager:
     def test_parse_empty_side_file(self, mocker):
         mocker.patch('side_runner_py.side.open')
-        mocker.patch('json.load').return_value = {'id': 'foobar', 'suites': [], 'tests': []}
+        mocker.patch('side_runner_py.side._try_to_load').return_value = {'id': 'foobar', 'suites': [], 'tests': []}
         side_manager = SIDEProjectManager()
         side_manager.add_project('foobar.side', 'foobar_params.json')
 
     def test_parse_invalid_side_file(self, mocker):
         mocker.patch('side_runner_py.side.open')
-        mocker.patch('json.load').return_value = {}
+        mocker.patch('side_runner_py.side._try_to_load').return_value = {}
 
         with pytest.raises(KeyError):
             side_manager = SIDEProjectManager()
@@ -20,7 +21,7 @@ class TestSIDEProjectManager:
 
     def test_attach_empty_params(self, mocker):
         mocker.patch('side_runner_py.side.open')
-        mocker.patch('json.load').return_value = {}
+        mocker.patch('side_runner_py.side._try_to_load').return_value = {}
 
         tests = []
         side_manager = SIDEProjectManager()
@@ -39,7 +40,7 @@ class TestSIDEProjectManager:
             },
         ]
         mocker.patch('side_runner_py.side.open')
-        mocker.patch('json.load').return_value = params
+        mocker.patch('side_runner_py.side._try_to_load').return_value = params
 
         tests = {'foobar': {"id": "foobar", "name": "Input form"}}
         side_manager = SIDEProjectManager()
@@ -60,7 +61,7 @@ class TestSIDEProjectManager:
             },
         ]
         mocker.patch('side_runner_py.side.open')
-        mocker.patch('json.load').return_value = params
+        mocker.patch('side_runner_py.side._try_to_load').return_value = params
 
         tests = {'foobar': {"id": "foobar", "name": "Input form"}}
         side_manager = SIDEProjectManager()
@@ -137,12 +138,19 @@ class TestSIDEProjectManager:
         assert tests_a == {'foobar_a': {'id': 'foobar_a'}}
         assert tests_b == {'foobar_a': {'id': 'foobar_a'}, 'foobar_b': {'id': 'foobar_b'}}
 
-    def test_parse_yaml_side_file(self, mocker):
-        mocker.patch('side_runner_py.side.open')
-        mocker.patch('json.load').side_effect = Exception()
-        mocker.patch('yaml.safe_load').return_value = {}
+    def test_parse_yaml_side_file(self, tmp_path):
+        sidefile = tmp_path / "yaml.side"
+        orig_test_project = {'suites': [], 'tests': [], 'id': 'foobar'}
+        sidefile.write_text(yaml.dump(orig_test_project))
 
-        tests = []
+        paramsfile = tmp_path / "yaml_params.yml"
+        orig_params = []
+        paramsfile.write_text(yaml.dump(orig_params))
+
         side_manager = SIDEProjectManager()
-        side_manager._attach_params('foobar.yml', tests)
-        assert tests == []
+        project_id = side_manager.add_project(str(sidefile), str(paramsfile))
+        test_project, test_suites, tests = side_manager.get_project(project_id)
+
+        assert project_id == 'foobar'
+        assert test_suites == orig_test_project['suites']
+        assert tests == {}


### PR DESCRIPTION
These commits added yaml side file support.
If `.side` file can be decoded by JSON, side parser try to load as YAML.

And I added file-path candidates of the params file.
It will be loaded in order of below;
* `<sidefilename>_params.json`
* `<sidefilename>_params.yml`
* `<sidefilename>_params.yaml`
* Nothing