### PR TITLE
Fix parameterizing with shared side

### DIFF
--- a/side_runner_py/side.py
+++ b/side_runner_py/side.py
@@ -32,7 +32,7 @@ class SIDEProjectManager:
         test_project = self.projects[project_id]
 
         # deepcopy tests
-        tests = deepcopy(test_project['tests'])
+        tests = deepcopy(self.tests)
         test_suites = deepcopy(test_project['test_suites'])
 
         # expand parameters if param file exists
@@ -40,11 +40,7 @@ class SIDEProjectManager:
             self._attach_params(test_project['param_filename'], tests)
             test_suites, tests = self._expand_test_project_with_params(test_suites, tests)
 
-        # extend manager's tests and parameter expanded tests
-        all_tests = deepcopy(self.tests)
-        all_tests.update(tests)
-
-        return test_project['project'], test_suites, all_tests
+        return test_project['project'], test_suites, tests
 
     def _parse_side(self, filename):
         # parse json


### PR DESCRIPTION
This PR fixed the issue that parameterizing does not work with shared side file.

Note that `get_project()` returns all tests including shared tests, but the only tests referenced by `test_suites['tests']` will be executed .