### PR TITLE
Improve failure handling

### DIFF
--- a/side_runner_py/commands.py
+++ b/side_runner_py/commands.py
@@ -7,6 +7,7 @@ from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.select import Select
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.common.exceptions import NoAlertPresentException
+from .exceptions import AssertionFailure, VerificationFailure
 from .log import getLogger
 logger = getLogger(__name__)
 
@@ -128,13 +129,13 @@ def execute_assert_confirmation(driver, store, test_project, test_suite, test_di
             if expect in actual:
                 return True
             else:
-                raise Exception('execute_assert_confirmation: expected {}, actual {}'.format(expect, actual))
+                raise AssertionFailure('execute_assert_confirmation', 'confirmation', expect, actual)
         except NoAlertPresentException:
             # FIXME: make configurable
             time.sleep(1)
             elapsed_seconds += 1
             if elapsed_seconds > Config.DRIVER_ELEMENT_WAIT:
-                raise Exception('execute_assert_confirmation: expected {}, timed out'.format(expect))
+                raise AssertionFailure('execute_assert_confirmation', 'confirmation', expect, '<timed out>')
             else:
                 continue
 
@@ -149,12 +150,16 @@ def execute_assert_text(driver, store, test_project, test_suite, test_dict):
     actual = element.text
     logger.info('ASSERT TEXT: expected {}, actual {}'.format(expect, actual))
     if expect != actual:
-        raise Exception('execute_assert_text: expected {}, actual {}'.format(expect, actual))
+        raise AssertionFailure('execute_assert_text', test_dict['target'], expect, actual)
 
 
 def execute_verify_text(driver, store, test_project, test_suite, test_dict):
+    expect = test_dict['value']
     element = _wait_element(driver, test_dict['target'])
+    actual = element.text
     logger.info('VERIFY TEXT: expected {}, actual {}'.format(test_dict['value'], element.text))
+    if expect != actual:
+        raise VerificationFailure('execute_verify_text', test_dict['target'], expect, actual)
 
 
 def execute_assert(driver, store, test_project, test_suite, test_dict):
@@ -162,13 +167,15 @@ def execute_assert(driver, store, test_project, test_suite, test_dict):
     actual = store.get(test_dict['target'])
     logger.info('ASSERT: expected {}, actual {}'.format(expect, actual))
     if expect != actual:
-        raise Exception('execute_assert: expected {}, actual {}'.format(expect, actual))
+        raise AssertionFailure('execute_assert', test_dict['target'], expect, actual)
 
 
 def execute_verify(driver, store, test_project, test_suite, test_dict):
     expect = test_dict['value']
     actual = store.get(test_dict['target'])
     logger.info('VERIFY: expected {}, actual {}'.format(expect, actual))
+    if expect != actual:
+        raise VerificationFailure('execute_verify', test_dict['target'], expect, actual)
 
 
 def execute_store(driver, store, test_project, test_suite, test_dict):

--- a/side_runner_py/exceptions.py
+++ b/side_runner_py/exceptions.py
@@ -1,0 +1,31 @@
+_msg_fmt = '''Failed to {} (command: {}, target: {})
+Expected
+  {}
+Actual
+  {}'''
+
+
+def _format_msg(exc, kind):
+    return _msg_fmt.format(kind, exc.command_name, exc.target, exc.expected, exc.actual)
+
+
+class AssertionFailure(Exception):
+    def __init__(self, command_name='', target='', expected='', actual=''):
+        self.command_name = command_name
+        self.target = target
+        self.expected = expected
+        self.actual = actual
+
+    def format_msg(self):
+        return _format_msg(self, 'assert')
+
+
+class VerificationFailure(Exception):
+    def __init__(self, command_name='', target='', expected='', actual=''):
+        self.command_name = command_name
+        self.target = target
+        self.expected = expected
+        self.actual = actual
+
+    def format_msg(self):
+        return _format_msg(self, 'verify')

--- a/side_runner_py/main.py
+++ b/side_runner_py/main.py
@@ -17,6 +17,7 @@ from .config import Config
 from .side import SIDEProjectManager
 from .hook import run_hook_per_project, run_hook_per_suite, run_hook_per_test
 from .variable import VariableStore
+from .exceptions import AssertionFailure, VerificationFailure
 
 from .log import getLogger
 logger = getLogger(__name__)
@@ -32,7 +33,7 @@ def get_screenshot(driver, test_suite_name, test_case_name, cmd_index, test_dict
         logger.warning(traceback.format_exc())
 
 
-def _format_test_command_output(test, is_failed, failed_msg):
+def _format_test_command_output(test, is_failed, failed_msg, failed_type):
     # generate test result
     return {
         'comment': test.get('comment'),
@@ -40,7 +41,8 @@ def _format_test_command_output(test, is_failed, failed_msg):
         'target': test['target'],
         'value': test['value'],
         'is_failed': is_failed,
-        'failed_msg': failed_msg
+        'failed_msg': failed_msg,
+        'failed_type': failed_type,
     }
 
 
@@ -48,11 +50,16 @@ def execute_test_command(driver, variable_store, test_project, test_suite, test_
     try:
         handler_func = TEST_HANDLER_MAP[test_dict['command']]
         handler_func(driver, variable_store, test_project, test_suite, test_dict)
+    except VerificationFailure as exc:
+        return _format_test_command_output(test_dict, False, exc.format_msg(), 'verify')
+    except AssertionFailure as exc:
+        logger.warning(exc.format_msg())
+        return _format_test_command_output(test_dict, True, exc.format_msg(), 'assert')
     except Exception:
         traceback_msg = traceback.format_exc()
         logger.warning(traceback_msg)
-        return _format_test_command_output(test_dict, True, traceback_msg)
-    return _format_test_command_output(test_dict, False, "")
+        return _format_test_command_output(test_dict, True, traceback_msg, 'unknown')
+    return _format_test_command_output(test_dict, False, '', '')
 
 
 def _ensure_test_output_by_id(output, some_id, create):
@@ -136,6 +143,8 @@ class SessionManager():
             yield _
             run_hook_per_suite('post', test_project, test_suite)
             logger.debug('Leave test-suite {}'.format(test_suite['id']))
+        except AssertionFailure:
+            pass
         except Exception:
             traceback_msg = traceback.format_exc()
             logger.warning(traceback_msg)
@@ -193,7 +202,10 @@ def _execute_test_command(driver, variable_store, test_project, test_suite, test
 
     if test_command_output['is_failed']:
         get_screenshot(driver, test_suite['name'], tests['name'], idx, test, outdir)
-        raise Exception(test_command_output)
+        if test_command_output['failed_type'] == 'assert':
+            raise AssertionFailure()
+        else:
+            raise Exception(test_command_output)
 
 
 def _execute_side_file(session_manager, side_manager, project_id):

--- a/side_runner_py/main.py
+++ b/side_runner_py/main.py
@@ -33,7 +33,7 @@ def get_screenshot(driver, test_suite_name, test_case_name, cmd_index, test_dict
         logger.warning(traceback.format_exc())
 
 
-def _format_test_command_output(test, is_failed, failed_msg, failed_type):
+def _format_test_command_output(test, is_failed, is_verify_failed, failed_msg, failed_type):
     # generate test result
     return {
         'comment': test.get('comment'),
@@ -41,6 +41,7 @@ def _format_test_command_output(test, is_failed, failed_msg, failed_type):
         'target': test['target'],
         'value': test['value'],
         'is_failed': is_failed,
+        'is_verify_failed': is_verify_failed,
         'failed_msg': failed_msg,
         'failed_type': failed_type,
     }
@@ -51,15 +52,15 @@ def execute_test_command(driver, variable_store, test_project, test_suite, test_
         handler_func = TEST_HANDLER_MAP[test_dict['command']]
         handler_func(driver, variable_store, test_project, test_suite, test_dict)
     except VerificationFailure as exc:
-        return _format_test_command_output(test_dict, False, exc.format_msg(), 'verify')
+        return _format_test_command_output(test_dict, False, True, exc.format_msg(), 'verify')
     except AssertionFailure as exc:
         logger.warning(exc.format_msg())
-        return _format_test_command_output(test_dict, True, exc.format_msg(), 'assert')
+        return _format_test_command_output(test_dict, True, False, exc.format_msg(), 'assert')
     except Exception:
         traceback_msg = traceback.format_exc()
         logger.warning(traceback_msg)
-        return _format_test_command_output(test_dict, True, traceback_msg, 'unknown')
-    return _format_test_command_output(test_dict, False, '', '')
+        return _format_test_command_output(test_dict, True, False, traceback_msg, 'unknown')
+    return _format_test_command_output(test_dict, False, False, '', '')
 
 
 def _ensure_test_output_by_id(output, some_id, create):


### PR DESCRIPTION
Resolve #34 
Resolve #23 also

This PR improved logging and result output when assertion or verification is failed.

Log output example;
```
runner_1     | 2019-04-17T16:41:54Z INFO side_runner_py.commands: ASSERT TEXT: expected Expected Message, actual Actual Message
runner_1     | 2019-04-17T16:41:54Z WARNING side_runner_py.main: Failed to assert (command: execute_assert_text, target: id=display)
runner_1     | Expected
runner_1     |   Expected Message
runner_1     | Actual
runner_1     |   Actual Message
runner_1     | 2019-04-17T16:41:54Z INFO side_runner_py.main: Close session <selenium.webdriver.remote.webdriver.WebDriver (session="c623ada8f79824e0abf4bbad1ca6307b")>
```

@yaamai Should I add unit tests?