### PR TITLE
Test name refs in suites

### DIFF
--- a/examples/sides/reference.side
+++ b/examples/sides/reference.side
@@ -1,0 +1,25 @@
+{
+  "id": "154f9754-70a3-4490-bdcc-ca2eb65b5f51",
+  "version": "2.0",
+  "name": "Reference the other side file",
+  "url": "https://www.seleniumeasy.com",
+  "tests": [],
+  "suites": [{
+    "id": "4089f59a-d04f-4300-9c71-70afd7ef4853",
+    "name": "Reference by id",
+    "persistSession": true,
+    "parallel": false,
+    "timeout": 300,
+    "tests": ["bcbde192-a28d-4c2b-996e-36fb1358a9f9"]
+  }, {
+    "id": "95d9a3b3-e1f0-4659-ac17-ff5e8fe9b1c7",
+    "name": "Reference by name",
+    "persistSession": true,
+    "parallel": false,
+    "timeout": 300,
+    "testNames": ["Radio button"]
+  }],
+  "urls": ["https://www.seleniumeasy.com/"],
+  "plugins": []
+}
+

--- a/side_runner_py/exceptions.py
+++ b/side_runner_py/exceptions.py
@@ -29,3 +29,8 @@ class VerificationFailure(Exception):
 
     def format_msg(self):
         return _format_msg(self, 'verify')
+
+
+class UnresolvedTestId(Exception):
+    def __init__(self, msg):
+        self.msg = msg

--- a/side_runner_py/side.py
+++ b/side_runner_py/side.py
@@ -35,6 +35,9 @@ class SIDEProjectManager:
         tests = deepcopy(self.tests)
         test_suites = deepcopy(test_project['test_suites'])
 
+        # resolve test id from test name in suites
+        self._resolve_test_id_from_name(test_suites, tests)
+
         # expand parameters if param file exists
         if test_project['param_filename']:
             self._attach_params(test_project['param_filename'], tests)
@@ -57,6 +60,14 @@ class SIDEProjectManager:
             tests[test['id']] = test
 
         return test_project, test_suites, tests
+
+    def _resolve_test_id_from_name(self, test_suites, tests):
+        for test_suite in test_suites:
+            if 'tests' not in test_suite and 'testNames' in test_suite:
+                test_ids = []
+                for test_name in test_suite['testNames']:
+                    test_ids.append(_get_test_id(tests, test_name))
+                test_suite['tests'] = test_ids
 
     def _attach_params(self, params_filename, tests):
         # parse json


### PR DESCRIPTION
This PR allowed new format of test suite like below;
```
suites:
- testNames:
  - login
  - something
  - logout
```

It's enabled only when `tests` is not defined and `testNames` is defined.