### PR TITLE
Pass the current test objects to hook functions

### DIFF
--- a/examples/hooks/per_test_post.py
+++ b/examples/hooks/per_test_post.py
@@ -5,5 +5,5 @@ conditions = {
 }
 
 
-def post_suite_run():
+def post_test_run():
     pass

--- a/examples/hooks/per_test_pre.py
+++ b/examples/hooks/per_test_pre.py
@@ -5,5 +5,5 @@ conditions = {
 }
 
 
-def pre_suite_run():
+def pre_test_run():
     pass

--- a/side_runner_py/hook.py
+++ b/side_runner_py/hook.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from functools import partial
 from importlib.machinery import SourceFileLoader
 from .config import Config
+from .utils import call_with_argname_bind
 
 from .log import getLogger
 logger = getLogger(__name__)
@@ -29,7 +30,7 @@ def load_hook_scripts(hook_script_dir, pattern):
             yield loader.load_module()
 
 
-def _run_hook(pre_or_post, kind, match_funcs):
+def _run_hook(pre_or_post, kind, match_funcs, current_test_dict):
     method_name = '{}_{}_run'.format(pre_or_post, kind)
 
     for hook_module in load_hook_scripts(Config.HOOK_SCRIPTS_DIR, '*.py'):
@@ -40,7 +41,8 @@ def _run_hook(pre_or_post, kind, match_funcs):
         if all([f(conditions) for f in match_funcs]):
             if getattr(hook_module, method_name, None):
                 logger.info('Call {}-{} hookscript {}.py'.format(pre_or_post, kind, hook_module.__name__))
-                getattr(hook_module, method_name)()
+                func = getattr(hook_module, method_name)
+                call_with_argname_bind(func, current_test_dict)
 
 
 def run_hook_per_project(pre_or_post, test_project):
@@ -48,7 +50,10 @@ def run_hook_per_project(pre_or_post, test_project):
     match_funcs = [
         partial(_contains_id_or_name, 'test_project', test_project),
     ]
-    _run_hook(pre_or_post, kind, match_funcs)
+    current_test_dict = {
+        'test_project': test_project,
+    }
+    _run_hook(pre_or_post, kind, match_funcs, current_test_dict)
 
 
 def run_hook_per_suite(pre_or_post, test_project, test_suite):
@@ -57,7 +62,11 @@ def run_hook_per_suite(pre_or_post, test_project, test_suite):
         partial(_contains_id_or_name, 'test_project', test_project),
         partial(_contains_id_or_name, 'test_suite', test_suite),
     ]
-    _run_hook(pre_or_post, kind, match_funcs)
+    current_test_dict = {
+        'test_project': test_project,
+        'test_suite': test_suite,
+    }
+    _run_hook(pre_or_post, kind, match_funcs, current_test_dict)
 
 
 def run_hook_per_test(pre_or_post, test_project, test_suite, test):
@@ -67,4 +76,9 @@ def run_hook_per_test(pre_or_post, test_project, test_suite, test):
         partial(_contains_id_or_name, 'test_suite', test_suite),
         partial(_contains_id_or_name, 'test', test),
     ]
-    _run_hook(pre_or_post, kind, match_funcs)
+    current_test_dict = {
+        'test_project': test_project,
+        'test_suite': test_suite,
+        'test': test,
+    }
+    _run_hook(pre_or_post, kind, match_funcs, current_test_dict)

--- a/side_runner_py/utils.py
+++ b/side_runner_py/utils.py
@@ -1,4 +1,5 @@
 import time
+from inspect import signature, Parameter
 from .log import getLogger
 logger = getLogger(__name__)
 
@@ -11,3 +12,20 @@ def with_retry(retry, wait, func, *args):
             logger.info(exc)
         finally:
             time.sleep(wait)
+
+
+def call_with_argname_bind(func, args_dict):
+    params = signature(func).parameters
+    param_names = [
+        p.name
+        for p in params.values()
+        if p.kind == Parameter.POSITIONAL_OR_KEYWORD
+    ]
+
+    try:
+        if len(param_names) == len(args_dict) and all([k in param_names for k in args_dict.keys()]):
+            return func(**args_dict)
+        else:
+            return func()
+    except TypeError as exc:
+        logger.warning('Mismatch of hook function args: {}'.format(str(exc)))

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,49 @@
+from side_runner_py import utils
+
+
+def test_call_with_argname_bind_pos_match():
+    def _func(foo, bar):
+        return foo, bar
+
+    ret = utils.call_with_argname_bind(_func, {'foo': 0, 'bar': 1})
+    assert ret == (0, 1)
+
+
+def test_call_with_argname_bind_pos_mismatch():
+    def _func(foo, bar):
+        return foo, bar
+
+    ret = utils.call_with_argname_bind(_func, {'foo': 0, 'buz': 2})
+    assert ret is None
+
+
+def test_call_with_argname_bind_pos_with_default_match():
+    def _func(foo=-1, bar=-1):
+        return foo, bar
+
+    ret = utils.call_with_argname_bind(_func, {'foo': 0, 'bar': 1})
+    assert ret == (0, 1)
+
+
+def test_call_with_argname_bind_pos_with_default_mismatch():
+    def _func(foo=-1, bar=-1):
+        return foo, bar
+
+    ret = utils.call_with_argname_bind(_func, {'foo': 0, 'buz': 2})
+    assert ret == (-1, -1)
+
+
+def test_call_with_argname_bind_no_arg():
+    def _func():
+        return 'foobar'
+
+    ret = utils.call_with_argname_bind(_func, {'foo': 0, 'bar': 1})
+    assert ret == 'foobar'
+
+
+def test_call_with_argname_bind_kw_only():
+    def _func(*args, foo=-1, bar=-1, **kwargs):
+        return args, foo, bar, kwargs
+
+    ret = utils.call_with_argname_bind(_func, {'foo': 0, 'bar': 1})
+    assert ret == (tuple(), -1, -1, dict())


### PR DESCRIPTION
This PR modify hook functions to be able to receive the current test objects (`test_project`, `test_suite`, `test`).

This will change the hook function signatures like below;

```python
# with test objects
def pre_project_run(test_project):
    pass
def pre_suite_run(test_project, test_suite):
    pass
def pre_test_run(test_project, test_suite, test):
    pass
# or nothing
def pre_project_run():
    pass
def pre_suite_run():
    pass
def pre_test_run():
    pass
```

Resolve #36 
